### PR TITLE
Ollama API support

### DIFF
--- a/LLaMA2-13B-Psyfighter2.modelfile
+++ b/LLaMA2-13B-Psyfighter2.modelfile
@@ -1,0 +1,3 @@
+FROM LLaMA2-13B-Psyfighter2.Q4_K_M.gguf
+
+PARAMETER num_ctx 4096

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Optionally, you can use an [Ollama](https://ollama.com) API endpoint as the LLM.
 
 ```bash
 python3 -m cherryberry \
-	--ollama-host "http://localhost:11434 \
+	--ollama-host "http://localhost:11434" \
 	--ollama-model "psyfighter"
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,3 +113,21 @@ textual console
 # In another
 textual run --dev cherryberry.py --debug --model ...
 ```
+
+### Ollama support
+
+Optionally, you can use an [Ollama](https://ollama.com) API endpoint as the LLM.
+
+```bash
+python3 -m cherryberry \
+	--ollama-host "http://localhost:11434 \
+	--ollama-model "psyfighter"
+```
+
+Note: the model "psyfighter" doesn't exist on the Ollama hub, so you will have to create it.
+1. Download the model from [here](https://huggingface.co/KoboldAI/LLaMA2-13B-Psyfighter2-GGUF) (the Q4_K_M variant is recommended).
+2. Run the following command:
+
+```bash
+ollama create -n psyfighter -f LLaMA2-13B-Psyfighter2.modelfile
+```

--- a/cherryberry.py
+++ b/cherryberry.py
@@ -153,10 +153,12 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--threads", type=int)
     parser.add_argument("--mlock", action="store_true")
     parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--ollama-host", type=str)
+    parser.add_argument("--ollama-model", type=str)
     args = parser.parse_args()
 
-    if not os.path.isfile(args.model):
-        print("Pass model path as the first parameter")
+    if not (args.model and os.path.isfile(args.model)) and not (args.ollama_host and args.ollama_model):
+        print("Pass model path as the first parameter, or pass ollama-host and ollama-model")
 
     app = Cherryberry(args)
     app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+llama-cpp-python ~= 0.2.25 
+jinja2 >= 3.1.2  
+langchain >= 0.0.340 
+textual >= 0.44.0
+textual-dev >= 1.2.1  
+orjson >= 3.9.10
+argparse
+ollama >= 0.1.7


### PR DESCRIPTION
This adds the ability to point at a model hosted on an Ollama installation instead of running the model within the app.

1. Added two commandline arguments (ollama-host, ollama-model)
2. Added Ollama modelfile to create the psyfighter model
3. Updated readme with instructions
4. Added requirements.txt to make installing dependencies with pip easier

Tested on my system, which is a PC running Windows 11 and WSL. The Ollama installation is in Windows, and the app was run in WSL.